### PR TITLE
Test less stuff in zip.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -79,3 +79,5 @@ if ! $YARN; then
   echo "-----> npm prune"
   npm prune
 fi
+
+rm -rf $build_dir/node_modules

--- a/bin/compile
+++ b/bin/compile
@@ -80,4 +80,5 @@ if ! $YARN; then
   npm prune
 fi
 
+echo "-----> clean up"
 rm -rf $build_dir/node_modules


### PR DESCRIPTION
We're getting build failures for what looks like too large a push, we _shouldn't_ need `/node_modules` after the build process, let's dump it!